### PR TITLE
Rutorrent mobile plugin

### DIFF
--- a/roles/rutorrent/tasks/main.yaml
+++ b/roles/rutorrent/tasks/main.yaml
@@ -20,9 +20,11 @@
 - name: clone rutorrent
   git: repo=https://github.com/Novik/ruTorrent.git
        dest=/usr/local/www/rutorrent
-       version=ac2db1536302bdc5b27aff6b15d54b0e9837fa59
-       update=no
+       version=9191af0c0910143a1a0dd4968e64f1db63a2d746
+       update=yes
+       force=yes
   register: rutorrent_cloned
+  notify: restart php-fpm
 
 - name: set base permissions on rutorrent files
   file: path=/usr/local/www/rutorrent state=directory

--- a/roles/rutorrent/tasks/main.yaml
+++ b/roles/rutorrent/tasks/main.yaml
@@ -26,11 +26,19 @@
   register: rutorrent_cloned
   notify: restart php-fpm
 
+- name: clone rutorrent mobile plugin
+  git: repo=https://github.com/xombiemp/rutorrentMobile.git
+       dest=/usr/local/www/rutorrent/plugins/mobile
+       version=2e177ab2cd670aba2d27f704b5354cfb81b9387d
+       update=yes
+  register: rutorrent_mobile_cloned
+  notify: restart php-fpm
+
 - name: set base permissions on rutorrent files
   file: path=/usr/local/www/rutorrent state=directory
         recurse=yes
         owner=root group=wheel mode='u=rwX,go=rX'
-  when: rutorrent_cloned|changed
+  when: rutorrent_cloned|changed or rutorrent_mobile_cloned|changed
 
 - name: change owner of share/ to rutorrent
   file: path=/usr/local/www/rutorrent/share state=directory


### PR DESCRIPTION
I'm not sure if `notify: restart php-fpm` is required, but it seemed like a reasonable thing to do.
The bump of ruTorrent to v3.8 should not be required for the mobile plugin to work. I just saw it was available.